### PR TITLE
ext files escaping, winCRLF, better error text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Abapmerge supports pragmas that can be written inside an abap comment. If writte
 Currently supported pragmas:
 - **include** {filename} > {string wrapper}
   - {filename} - path to the file relative to script execution dir (argv[0])
-  - {string wrapper} is a pattern where $$ is replaced by the include line
+  - {string wrapper} is a pattern where `$$` is replaced by the include line
+  - `$$` is escaped - ' replaced to '' (to fit in abap string), use `$$$` to skip escaping
 
 Example
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,10 +1,12 @@
 export default class File {
   private name: string;
   private contents: string;
+  private isUsed: boolean;
 
   public constructor(n: string, c: string) {
-    this.name = n;
+    this.name     = n;
     this.contents = c;
+    this.isUsed   = false;
   }
 
   public getName(): string {
@@ -13,5 +15,13 @@ export default class File {
 
   public getContents(): string {
     return this.contents;
+  }
+
+  public wasUsed(): boolean {
+    return this.isUsed;
+  }
+
+  public markUsed() {
+    this.isUsed = true;
   }
 }

--- a/test/abap/4/zmain.abap
+++ b/test/abap/4/zmain.abap
@@ -1,6 +1,6 @@
 report zmain.
 
-include zinc1.
+include zinc1. " A comment here
 include zinc2.
 
 write / 'Main include'.

--- a/test/abap/5/data.txt
+++ b/test/abap/5/data.txt
@@ -1,0 +1,1 @@
+content = 'X';

--- a/test/abap/5/zmain.abap
+++ b/test/abap/5/zmain.abap
@@ -4,3 +4,5 @@ write / 'Main include'.
 * @@abapmerge include style.css > write '$$'.
   " @@abapmerge include js/script.js > write '$$'.
   " @@abapmerge wrong pragma, just copy to output
+  " @@abapmerge include data.txt > write '$$'.
+  " @@abapmerge include data.txt > write '$$$'. " Unescaped !


### PR DESCRIPTION
- $$ now escape ' to '' (css and js allow ', so better to escape it just in case. Otherwise merged prog might not compile at all)
- take care of \r on windows files (abapgit did not assemble on Win because of that)
- better "Not all files used" output (lists files that were unused actually)