### PR TITLE
Use Powershell for testing    fixes #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: node_js
 node_js:
   - "6"
+
+os:
+  - linux
+
+install:
+  - pushd ci
+  - ./download-ps.sh
+  - popd
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - chmod +x ./download-ps.sh
   - ./download-ps.sh
   - popd
+  - npm install
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 
 os:
   - linux
+sudo: required
 
 install:
   - pushd ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ node_js:
 os:
   - linux
 sudo: required
+dist: trusty
 
 install:
   - pushd ci
+  - chmod +x ./download-ps.sh
   - ./download-ps.sh
   - popd
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Test online: http://larshp.github.io/abapmerge/
 
 * `npm test`
 
+Note: [Powershell](https://github.com/PowerShell/PowerShell) is used to execute the tests. Make sure you have it installed.
+* `powershell "write-host it works!"`
+
 ### Additional features
 
 Abapmerge supports pragmas that can be written inside an abap comment. If written as " comment, then indentation before " is also used for output.

--- a/ci/download-ps.sh
+++ b/ci/download-ps.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Let's quit on interrupt of subcommands
+trap '
+  trap - INT # restore default INT handler
+  echo "Interrupted"
+  kill -s INT "$$"
+' INT
+
+get_url() {
+    release=v6.0.0-alpha.16
+    echo "https://github.com/PowerShell/PowerShell/releases/download/$release/$1"
+}
+
+# Get OS specific asset ID and package name
+case "$OSTYPE" in
+    linux*)
+        source /etc/os-release
+        # Install curl and wget to download package
+        case "$ID" in
+            centos*)
+                if ! hash curl 2>/dev/null; then
+                    echo "curl not found, installing..."
+                    sudo yum install -y curl
+                fi
+
+                package=powershell-6.0.0_alpha.16-1.el7.centos.x86_64.rpm
+                ;;
+            ubuntu)
+                if ! hash curl 2>/dev/null; then
+                    echo "curl not found, installing..."
+                    sudo apt-get install -y curl
+                fi
+
+                case "$VERSION_ID" in
+                    14.04)
+                        package=powershell_6.0.0-alpha.16-1ubuntu1.14.04.1_amd64.deb
+                        ;;
+                    16.04)
+                        package=powershell_6.0.0-alpha.16-1ubuntu1.16.04.1_amd64.deb
+                        ;;
+                    *)
+                        echo "Ubuntu $VERSION_ID is not supported!" >&2
+                        exit 2
+                esac
+                ;;
+            *)
+                echo "$NAME is not supported!" >&2
+                exit 2
+        esac
+        ;;
+    darwin*)
+        # We don't check for curl as macOS should have a system version
+        package=powershell-6.0.0-alpha.16.pkg
+        ;;
+    *)
+        echo "$OSTYPE is not supported!" >&2
+        exit 2
+        ;;
+esac
+
+curl -L -o "$package" $(get_url "$package")
+
+if [[ ! -r "$package" ]]; then
+    echo "ERROR: $package failed to download! Aborting..." >&2
+    exit 1
+fi
+
+# Installs PowerShell package
+case "$OSTYPE" in
+    linux*)
+        source /etc/os-release
+        # Install dependencies
+        echo "Installing PowerShell with sudo..."
+        case "$ID" in
+            centos)
+                # yum automatically resolves dependencies for local packages
+                sudo yum install "./$package"
+                ;;
+            ubuntu)
+                # dpkg does not automatically resolve dependencies, but spouts ugly errors
+                sudo dpkg -i "./$package" &> /dev/null
+                # Resolve dependencies
+                sudo apt-get install -f
+                ;;
+            *)
+        esac
+        ;;
+    darwin*)
+        patched=0
+        if hash brew 2>/dev/null; then
+            if [[ ! -d $(brew --prefix openssl) ]]; then
+               echo "Installing OpenSSL with brew..."
+               if ! brew install openssl; then
+                   echo "ERROR: OpenSSL failed to install! Crypto functions will not work..." >&2
+                   # Don't abort because it is not fatal
+               elif ! brew install curl --with-openssl; then
+                   echo "ERROR: curl failed to build against OpenSSL; SSL functions will not work..." >&2
+                   # Still not fatal
+               else
+                   # OpenSSL installation succeeded; remember to patch System.Net.Http after PowerShell installation
+                   patched=1
+               fi
+            fi
+
+        else
+            echo "ERROR: brew not found! OpenSSL may not be available..." >&2
+            # Don't abort because it is not fatal
+        fi
+
+        echo "Installing $package with sudo ..."
+        sudo installer -pkg "./$package" -target /
+        if [[ $patched -eq 1 ]]; then
+            echo "Patching System.Net.Http for libcurl and OpenSSL..."
+            find /usr/local/microsoft/powershell -name System.Net.Http.Native.dylib | xargs sudo install_name_tool -change /usr/lib/libcurl.4.dylib /usr/local/opt/curl/lib/libcurl.4.dylib
+        fi
+        ;;
+esac
+
+powershell -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
+success=$?
+
+if [[ "$success" != 0 ]]; then
+    echo "ERROR: PowerShell failed to install!" >&2
+    exit "$success"
+fi

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && powershell -ExecutionPolicy Bypass -File ./test.ps1"
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell \"echo lalala test\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && powershell \"echo lalala test\""
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell ./test.ps1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && powershell -ExecutionPolicy Bypass -File ./test.ps1"
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell -File ./test.ps1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && powershell -File ./test.ps1"
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell -ExecutionPolicy Bypass -File ./test.ps1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && ./test.sh"
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell -File ./test.ps1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "tsc --pretty",
     "test": "tslint ./src/*.ts",
-    "posttest": "browserify build/web.js -o web/bundle.js && powershell ./test.ps1"
+    "posttest": "browserify build/web.js -o web/bundle.js && powershell -ExecutionPolicy Bypass -File ./test.ps1"
   },
   "repository": {
     "type": "git",

--- a/test.cmd
+++ b/test.cmd
@@ -1,7 +1,0 @@
-rem "Test script"
-node abapmerge test\abap\1\zmain.abap > NUL || exit /b
-node abapmerge test\abap\2\zmain.abap > NUL || exit /b
-node abapmerge test\abap\3\zmain.abap > NUL || exit /b
-node abapmerge test\abap\4\zmain.abap > NUL || exit /b
-node abapmerge test\abap\5\zmain.abap > NUL || exit /b
-echo "test successful"

--- a/test.ps1
+++ b/test.ps1
@@ -1,7 +1,7 @@
-write-host "Test scripts"
-node abapmerge .\test\abap\1\zmain.abap > $null
-node abapmerge .\test\abap\2\zmain.abap > $null
-node abapmerge .\test\abap\3\zmain.abap > $null
-node abapmerge .\test\abap\4\zmain.abap > $null
-node abapmerge .\test\abap\5\zmain.abap > $null
-write-host "Tests finished" -ForegroundColor Green
+write-host "starting tests..."
+node abapmerge ./test/abap/1/zmain.abap > $null
+node abapmerge ./test/abap/2/zmain.abap > $null
+node abapmerge ./test/abap/3/zmain.abap > $null
+node abapmerge ./test/abap/4/zmain.abap > $null
+node abapmerge ./test/abap/5/zmain.abap > $null
+write-host "All Tests completed" -ForegroundColor Green

--- a/test.ps1
+++ b/test.ps1
@@ -1,7 +1,7 @@
 write-host "Test scripts"
-node abapmerge test\abap\1\zmain.abap > $null
-node abapmerge test\abap\2\zmain.abap > $null
-node abapmerge test\abap\3\zmain.abap > $null
-node abapmerge test\abap\4\zmain.abap > $null
-node abapmerge test\abap\5\zmain.abap > $null
-write-host "Tests successful" -ForegroundColor Green
+node abapmerge .\test\abap\1\zmain.abap > $null
+node abapmerge .\test\abap\2\zmain.abap > $null
+node abapmerge .\test\abap\3\zmain.abap > $null
+node abapmerge .\test\abap\4\zmain.abap > $null
+node abapmerge .\test\abap\5\zmain.abap > $null
+write-host "Tests finished" -ForegroundColor Green

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,7 @@
+write-host "Test scripts"
+node abapmerge test\abap\1\zmain.abap > $null
+node abapmerge test\abap\2\zmain.abap > $null
+node abapmerge test\abap\3\zmain.abap > $null
+node abapmerge test\abap\4\zmain.abap > $null
+node abapmerge test\abap\5\zmain.abap > $null
+write-host "Tests successful" -ForegroundColor Green

--- a/test.ps1
+++ b/test.ps1
@@ -1,4 +1,4 @@
-write-host "starting tests..."
+write-host "Starting tests..."
 node abapmerge ./test/abap/1/zmain.abap > $null
 node abapmerge ./test/abap/2/zmain.abap > $null
 node abapmerge ./test/abap/3/zmain.abap > $null

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-./abapmerge test/abap/1/zmain.abap > /dev/null
-./abapmerge test/abap/2/zmain.abap > /dev/null
-./abapmerge test/abap/3/zmain.abap > /dev/null
-./abapmerge test/abap/4/zmain.abap > /dev/null
-./abapmerge test/abap/5/zmain.abap > /dev/null
-echo "test.sh successful"


### PR DESCRIPTION
This PR deletes the `test.sh` and `test.cmd `files and replaces them with an identical one written in Powershell. It does not verify the test results yet :innocent:. 

**Merging the PR introduces a dependency for Linux users, since PS is not pre-installed there.** 
Travis also needs to do some extra work now.

Best regards
Fabio

