### PR TITLE
Support for local imp & def

### DIFF
--- a/src/class_list.ts
+++ b/src/class_list.ts
@@ -3,7 +3,7 @@ import FileList from "./file_list";
 import Class from "./class";
 import Graph from "./graph";
 import InterfaceParser from "./interface_parser";
-import ClassParser from "./class_parser";
+import { ClassParser } from "./class_parser";
 
 export default class ClassList {
   private interfaces: Class[];
@@ -88,7 +88,7 @@ export default class ClassList {
       let f = list.get(i);
       if (f.getFilename().match(/\.clas\.abap$/)) {
         f.markUsed();
-        this.pushClass(f);
+        this.pushClass(f, list);
       } else if (f.getFilename().match(/\.clas\.testclasses\.abap$/)) {
         f.markUsed();
       } else if (f.getFilename().match(/\.intf\.abap$/)) {
@@ -98,9 +98,8 @@ export default class ClassList {
     }
   }
 
-  private pushClass(f: File): void {
-    let cls = ClassParser.parse(f);
-
+  private pushClass(f: File, list: FileList): void {
+    let cls = ClassParser.parse(f, list);
     if (cls.getName().match(/^.?CX_/i)) {
 // the DEFINITION DEFERRED does not work very well for exception classes
       this.exceptions.push(cls);

--- a/src/class_parser.ts
+++ b/src/class_parser.ts
@@ -1,25 +1,147 @@
 import File from "./file";
+import FileList from "./file_list";
 import Class from "./class";
+import Utils from "./utils";
 
-export default class ClassParser {
+export class AbapPublicClass {
+  public name: string;
+  public hash: string;
+  public def: string;
+  public imp: string;
+}
 
-  public static parse(f: File): Class {
+export class ClassParser {
+
+  public static anonymizeTypeName(prefix15: string, type: string, name: string): string {
+    let typeSeed = Utils.hashCodeOf(type);
+    let typeAlias = Utils.randomStringOfLength(typeSeed, 5);
+
+    let nameSeed = Utils.hashCodeOf(name);
+    let nameAlias = Utils.randomStringOfLength(nameSeed, 10);
+
+    return typeAlias + prefix15 + nameAlias;
+  }
+
+  public static renameLocalType(oldName: string, newName: string, parent: string, oldCode: string): string {
+    let occurrences = [
+      // interface declaration
+      { context: "* renamed: " + parent + " :: " + oldName + "\n",
+        regstr: "^(\s*interface\\s+)" + oldName + "(\\s*\\.)",
+      },
+      // class declaration
+      { context: "* renamed: " + parent + " :: " + oldName + "\n",
+        regstr: "^(\s*class\\s+)" + oldName + "(\\s+definition\\b)",
+      },
+      { context: "",
+        regstr:  "^([^*\"\\n]*\\b)" + oldName + "(\\b)",
+      },
+    ];
+
+    let newCode = oldCode;
+    for (let occurrence of occurrences) {
+      let regexp = new RegExp(occurrence.regstr, "igm");
+      newCode = newCode.replace(regexp, occurrence.context + "$1" + newName + "$2");
+    }
+
+    return newCode;
+  }
+
+  public static buildLocalFileName(part: string, publicClass: AbapPublicClass): string {
+    return publicClass.name + ".clas.locals_" + part + ".abap";
+  }
+
+  public static findFileByName(filename: string, list: FileList ): File {
+    filename = filename.toLowerCase();
+
+    let length = list.length();
+    for (let i = 0; i < length; ++i) {
+      let file = list.get(i);
+      if (filename === file.getFilename().toLowerCase()) {
+        return file;
+      }
+    }
+
+    return null;
+  }
+
+  public static parseLocalContents(part: string, publicClass: AbapPublicClass, local: string): void {
+    let global = local + "\n" + publicClass[part];
+
+    let regex = /^\s*((CLASS)\s+(\w+)\s+DEFINITION\s*[^\.]*|(INTERFACE)\s+(\w+)\s*)\./gim;
+    let definition;
+
+    /* tslint:disable:no-conditional-assignment */
+    while ((definition = regex.exec(local)) !== null) {
+      let type = definition[2];
+      let name = definition[3];
+
+      if (!type) {
+        // not class, dealing with interface
+        type = definition[4];
+        name = definition[5];
+      }
+
+      let alias = ClassParser.anonymizeTypeName(publicClass.hash, type, name);
+      global = ClassParser.renameLocalType(name, alias, publicClass.name, global);
+
+      // prepend (definition)? deferred
+      let decl = type + " " + alias;
+      if (type.toLowerCase() === "class") {
+        decl = decl + " DEFINITION";
+      }
+      global = decl + " DEFERRED.\n" + global;
+
+      // types of the local definitions are used in the (public|local)
+      // implementation. so, after we must update the implementation after
+      // we finish processing the local definitions.
+      if (part === "def") {
+        // this is the only difference between processing definitions and
+        // implementations - which can be handled by one function otherwise
+        publicClass.imp = ClassParser.renameLocalType(name, alias, publicClass.name, publicClass.imp);
+      }
+    }
+
+    publicClass[part] = global;
+  }
+
+  public static tryProcessLocalFile(part: string, publicClass: AbapPublicClass, list: FileList): void {
+    let filename = ClassParser.buildLocalFileName(part, publicClass);
+    let file = ClassParser.findFileByName(filename, list);
+    if (file === null) {
+      return;
+    }
+
+    let contents = file.getContents();
+    ClassParser.parseLocalContents(part, publicClass, contents);
+    file.markUsed();
+  }
+
+  public static parse(f: File, list: FileList): Class {
 
     let match = f.getContents().match(/^(([\s\S])*ENDCLASS\.)\s*(CLASS(.|\s)*)$/i);
     if (!match || !match[1] || !match[2] || !match[3]) {
       throw "error parsing class: " + f.getFilename();
     }
-    let name = f.getFilename().split(".")[0];
-    let def = this.makeLocal(name, match[1]);
 
-    let superMatch = def.match(/INHERITING FROM (Z\w+)/i);
+    let publicClass = new AbapPublicClass();
+    publicClass.name = f.getFilename().split(".")[0];
+    publicClass.hash = Utils.randomStringOfLength(Utils.hashCodeOf(publicClass.name), 15);
+    publicClass.def = this.makeLocal(publicClass.name, match[1]);
+    publicClass.imp = match[3];
+
+    // make sure we parse the imp part at the very first step!
+    ClassParser.tryProcessLocalFile("imp", publicClass, list);
+    // because the local definitions are used in the implementation.
+    ClassParser.tryProcessLocalFile("def", publicClass, list);
+
+    let superMatch = publicClass.def.match(/INHERITING FROM (Z\w+)/i);
 //    console.dir(superMatch);
     let dependencies = [];
     if (superMatch && superMatch[1]) {
       dependencies.push(superMatch[1].toLowerCase());
     }
 
-    return new Class(name, def, match[3], dependencies);
+    return new Class(publicClass.name, publicClass.def, publicClass.imp, dependencies);
   }
 
   private static makeLocal(name: string, s: string): string {
@@ -29,5 +151,4 @@ export default class ClassParser {
     ret = ret.replace(reg2, "FRIENDS ZCL_ABAPGIT");
     return ret;
   }
-
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,43 @@
+export default class Utils {
+
+  public static minstdRandMax = 2147483646;
+
+  public static nextMinstdRandFor(seed: number): number {
+    let product = 48271 * seed;
+    return product % (Utils.minstdRandMax + 1);
+  }
+
+  public static hashCodeOf(input: string): number {
+    let hash = 0;
+
+    if (input.length === 0) {
+      return hash;
+    }
+
+    for (let i = 0; i < input.length; ++i) {
+      let char = input.charCodeAt(i);
+      /* tslint:disable:no-bitwise */
+      hash = ( ( hash << 5 ) - hash ) + char;
+      /* tslint:disable:no-bitwise */
+      hash = hash & hash;
+    }
+
+    if (hash < 0) {
+        return hash * -1;
+    }
+
+    return hash;
+  }
+
+  public static randomStringOfLength(seed: number, requiredLength: number): string {
+    let allowedLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    let result = "";
+    for (let currentLength = 0; currentLength < requiredLength; ++currentLength) {
+      seed = Utils.nextMinstdRandFor(seed);
+      result += allowedLetters[Math.floor(allowedLetters.length * (seed / Utils.minstdRandMax))];
+    }
+
+    return result;
+  }
+}

--- a/test/class_parser.ts
+++ b/test/class_parser.ts
@@ -1,0 +1,450 @@
+import * as chai from "chai";
+import File from "../src/file";
+import FileList from "../src/file_list";
+import {ClassParser, AbapPublicClass} from "../src/class_parser";
+
+let expect = chai.expect;
+
+describe("class_parser 1, anonymizeTypeName contract", () => {
+  it("something", () => {
+    let prefix = "prefix";
+    let alias = ClassParser.anonymizeTypeName(prefix, "type", "name");
+
+    let anotherprefix = "foobar";
+    let anotheralias = ClassParser.anonymizeTypeName(anotherprefix, "type", "name");
+
+    expect(alias.length).to.equal(15 + prefix.length);
+    expect(alias.substr(5, prefix.length)).to.equal(prefix);
+    expect(alias.substr(0, 5)).to.equal(anotheralias.substr(0, 5));
+    expect(alias.substring(5 + prefix.length + 1, alias.length - 1)).to.equal(
+            anotheralias.substring(5 + anotherprefix.length + 1, anotheralias.length - 1));
+  });
+});
+
+describe("class_parser 2, renameLocalType class member", () => {
+  it("something", () => {
+    let oldCode = "data(res) = cl_foo=>do_stuff().";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_bar", "cl_parent", oldCode);
+    expect(newCode).to.equal("data(res) = cl_bar=>do_stuff().");
+  });
+});
+
+describe("class_parser 3, renameLocalType new", () => {
+  it("something", () => {
+    let oldCode = "data(res) = new cl_foo( ).";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_bar", "cl_parent", oldCode);
+    expect(newCode).to.equal("data(res) = new cl_bar( ).");
+  });
+});
+
+describe("class_parser 4, renameLocalType ref to", () => {
+  it("something", () => {
+    let oldCode = "data: res type ref to cl_foo.";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_bar", "cl_parent", oldCode);
+    expect(newCode).to.equal("data: res type ref to cl_bar.");
+  });
+});
+
+describe("class_parser 5, renameLocalType class definition", () => {
+  it("something", () => {
+    let oldCode = "class cl_foo definition.";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_bar", "cl_parent", oldCode);
+    expect(newCode).to.equal("* renamed: cl_parent :: cl_foo\n" +
+                             "class cl_bar definition.");
+  });
+});
+
+describe("class_parser 6, renameLocalType class implementation", () => {
+  it("something", () => {
+    let oldCode = "class cl_foo implementation.";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_bar", "cl_parent", oldCode);
+    expect(newCode).to.equal("class cl_bar implementation.");
+  });
+});
+
+describe("class_parser 7, renameLocalType interface declaration", () => {
+  it("something", () => {
+    let oldCode = "interface lif_foo.\nclass lcl_imp definition.\ninterfaces lif_foo.\nendclass.\n";
+    let newCode = ClassParser.renameLocalType("lif_foo", "lif_bar", "cl_parent", oldCode);
+
+    expect(newCode).to.equal("* renamed: cl_parent :: lif_foo\n" +
+                             "interface lif_bar.\n" +
+                             "class lcl_imp definition.\ninterfaces lif_bar.\nendclass.\n");
+  });
+});
+
+describe("class_parser 8, buildLocalFileName imp", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+
+    let filename = ClassParser.buildLocalFileName("imp", abapClass);
+
+    expect(filename).to.equal("cl_foo.clas.locals_imp.abap");
+  });
+});
+
+describe("class_parser 9, buildLocalFileName def", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+
+    let filename = ClassParser.buildLocalFileName("def", abapClass);
+
+    expect(filename).to.equal("cl_foo.clas.locals_def.abap");
+  });
+});
+
+describe("class_parser 10, parseLocalContents contract class", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.hash = "XOX";
+    abapClass.def = "lcl_def=>def_imp";
+    abapClass.imp = "lcl_def=>def_imp lcl_imp=>imp_only";
+
+    let oldLocalDef = "class lcl_def definition.";
+    let oldLocalImp = "class lcl_imp definition.";
+
+    ClassParser.parseLocalContents("imp", abapClass, oldLocalImp);
+
+    expect(abapClass.def).to.equal("lcl_def=>def_imp");
+    expect(abapClass.imp).to.equal("class GiiGhXOXVndeoIopfZ DEFINITION DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lcl_imp\n" +
+                                   "class GiiGhXOXVndeoIopfZ definition.\n" +
+                                   "lcl_def=>def_imp GiiGhXOXVndeoIopfZ=>imp_only");
+
+    ClassParser.parseLocalContents("def", abapClass, oldLocalDef);
+
+    expect(abapClass.def).to.equal("class GiiGhXOXPMwTAnXjaE DEFINITION DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lcl_def\n" +
+                                   "class GiiGhXOXPMwTAnXjaE definition.\n" +
+                                   "GiiGhXOXPMwTAnXjaE=>def_imp");
+    expect(abapClass.imp).to.equal("class GiiGhXOXVndeoIopfZ DEFINITION DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lcl_imp\n" +
+                                   "class GiiGhXOXVndeoIopfZ definition.\n" +
+                                   "GiiGhXOXPMwTAnXjaE=>def_imp GiiGhXOXVndeoIopfZ=>imp_only");
+  });
+});
+
+describe("class_parser 11, parseLocalContents contract interface", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.hash = "XOX";
+    abapClass.def = "lif_def=>def_imp";
+    abapClass.imp = "lif_def=>def_imp lif_imp=>imp_only";
+
+    let oldLocalDef = "interface lif_def.";
+    let oldLocalImp = "interface lif_imp.";
+
+    ClassParser.parseLocalContents("imp", abapClass, oldLocalImp);
+
+    expect(abapClass.def).to.equal("lif_def=>def_imp");
+    expect(abapClass.imp).to.equal("interface WboRqXOXAKOYzxghOo DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lif_imp\n" +
+                                   "interface WboRqXOXAKOYzxghOo.\n" +
+                                   "lif_def=>def_imp WboRqXOXAKOYzxghOo=>imp_only");
+
+    ClassParser.parseLocalContents("def", abapClass, oldLocalDef);
+
+    expect(abapClass.def).to.equal("interface WboRqXOXujgMLcQaJU DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lif_def\n" +
+                                   "interface WboRqXOXujgMLcQaJU.\n" +
+                                   "WboRqXOXujgMLcQaJU=>def_imp");
+    expect(abapClass.imp).to.equal("interface WboRqXOXAKOYzxghOo DEFERRED.\n" +
+                                   "* renamed: cl_foo :: lif_imp\n" +
+                                   "interface WboRqXOXAKOYzxghOo.\n" +
+                                   "WboRqXOXujgMLcQaJU=>def_imp WboRqXOXAKOYzxghOo=>imp_only");
+  });
+});
+
+describe("class_parser 12, parseLocalContents comments", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.hash = "_XOX_";
+    abapClass.def = "";
+    abapClass.imp = "";
+
+    let oldLocalImp = "* interface foo definition.\n" +
+                      "class utils definition.\n";
+
+    ClassParser.parseLocalContents("imp", abapClass, oldLocalImp);
+
+    expect(abapClass.def).to.equal("");
+    expect(abapClass.imp).to.equal("class GiiGh_XOX_QFKeljuxmY DEFINITION DEFERRED.\n" +
+                                   "* interface foo definition.\n" +
+                                   "* renamed: cl_foo :: utils\n" +
+                                   "class GiiGh_XOX_QFKeljuxmY definition.\n\n");
+  });
+});
+
+describe("class_parser 13, findFileByName", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("camelCASEfile", "camelCASEfile"));
+    files.push(new File("INVERTEDcaseFILE", "INVERTEDcaseFILE"));
+
+    expect(ClassParser.findFileByName("CAMELcaseFILE", files).getContents()).to.equal("camelCASEfile");
+    expect(ClassParser.findFileByName("invertedCASEfile", files).getContents()).to.equal("INVERTEDcaseFILE");
+  });
+});
+
+describe("class_parser 14, tryProcessLocalFile not found imp", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.def = "";
+    abapClass.imp = "";
+
+    let mainFile = new File("cl_foo.clas.abap", "class cl_foo definition.");
+    let defFile = new File("cl_foo.clas.locals_def.abap", "interface lif_bar.");
+    let files = new FileList();
+    files.push(mainFile);
+    files.push(defFile);
+
+    ClassParser.tryProcessLocalFile("imp", abapClass, files);
+
+    expect(mainFile.wasUsed()).to.equal(false);
+    expect(defFile.wasUsed()).to.equal(false);
+
+    expect(abapClass.def).to.equal("");
+    expect(abapClass.imp).to.equal("");
+  });
+});
+
+describe("class_parser 15, tryProcessLocalFile not found def", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.def = "";
+    abapClass.imp = "";
+
+    let mainFile = new File("cl_foo.clas.abap", "class cl_foo definition.");
+    let impFile = new File("cl_foo.clas.locals_imp.abap", "class lcl_bar definition.");
+    let files = new FileList();
+    files.push(mainFile);
+
+    ClassParser.tryProcessLocalFile("def", abapClass, files);
+
+    expect(mainFile.wasUsed()).to.equal(false);
+    expect(impFile.wasUsed()).to.equal(false);
+
+    expect(abapClass.def).to.equal("");
+    expect(abapClass.imp).to.equal("");
+  });
+});
+
+describe("class_parser 16, tryProcessLocalFile unknown", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.def = "";
+    abapClass.imp = "";
+
+    let mainFile = new File("cl_foo.clas.abap", "class cl_foo definition.");
+    let defFile = new File("cl_foo.clas.locals_def.abap", "interface lif_blah.");
+    let impFile = new File("cl_foo.clas.locals_imp.abap", "class lcl_bar definition.");
+    let files = new FileList();
+    files.push(mainFile);
+    files.push(defFile);
+    files.push(impFile);
+
+    ClassParser.tryProcessLocalFile("omg", abapClass, files);
+
+    expect(mainFile.wasUsed()).to.equal(false);
+    expect(defFile.wasUsed()).to.equal(false);
+    expect(impFile.wasUsed()).to.equal(false);
+
+    expect(abapClass.def).to.equal("");
+    expect(abapClass.imp).to.equal("");
+  });
+});
+
+describe("class_parser 17, tryProcessLocalFile found", () => {
+  it("something", () => {
+    let abapClass = new AbapPublicClass();
+    abapClass.name = "cl_foo";
+    abapClass.def = "";
+    abapClass.imp = "";
+
+    let mainFile = new File("cl_foo.clas.abap", "class cl_foo definition.");
+    let defFile = new File("cl_foo.clas.locals_def.abap", "* comment def");
+    let impFile = new File("cl_foo.clas.locals_imp.abap", "* comment imp");
+    let files = new FileList();
+    files.push(mainFile);
+    files.push(defFile);
+    files.push(impFile);
+
+    ClassParser.tryProcessLocalFile("imp", abapClass, files);
+
+    expect(mainFile.wasUsed()).to.equal(false);
+    expect(defFile.wasUsed()).to.equal(false);
+    expect(impFile.wasUsed()).to.equal(true);
+
+    expect(abapClass.def).to.equal("");
+    expect(abapClass.imp).to.equal("* comment imp\n");
+
+    ClassParser.tryProcessLocalFile("def", abapClass, files);
+
+    expect(mainFile.wasUsed()).to.equal(false);
+    expect(defFile.wasUsed()).to.equal(true);
+    expect(impFile.wasUsed()).to.equal(true);
+
+    expect(abapClass.def).to.equal("* comment def\n");
+    expect(abapClass.imp).to.equal("* comment imp\n");
+  });
+});
+
+describe("class_parser 19, renameLocalType exception in catch with into", () => {
+  it("something", () => {
+    let oldCode = "catch cl_foo cl_bar into";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+    expect(newCode).to.equal("catch cl_new cl_bar into");
+
+    let newCode2 = ClassParser.renameLocalType("cl_bar", "cl_future", "cl_parent", newCode);
+    expect(newCode2).to.equal("catch cl_new cl_future into");
+  });
+});
+
+describe("class_parser 20, renameLocalType exception in catch w/o into", () => {
+  it("something", () => {
+    let oldCode = "catch cl_foo cl_bar.";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+    expect(newCode).to.equal("catch cl_new cl_bar.");
+
+    let newCode2 = ClassParser.renameLocalType("cl_bar", "cl_future", "cl_parent", newCode);
+    expect(newCode2).to.equal("catch cl_new cl_future.");
+  });
+});
+
+describe("class_parser 21, renameLocalType exception in catch before unwind with into", () => {
+  it("something", () => {
+    let oldCode = "catch cl_foo cl_bar into";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+    expect(newCode).to.equal("catch cl_new cl_bar into");
+
+    let newCode2 = ClassParser.renameLocalType("cl_bar", "cl_future", "cl_parent", newCode);
+    expect(newCode2).to.equal("catch cl_new cl_future into");
+  });
+});
+
+describe("class_parser 22, renameLocalType exception in catch before unwind w/o into", () => {
+  it("something", () => {
+    let oldCode = "catch cl_foo cl_bar.";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+    expect(newCode).to.equal("catch cl_new cl_bar.");
+
+    let newCode2 = ClassParser.renameLocalType("cl_bar", "cl_future", "cl_parent", newCode);
+    expect(newCode2).to.equal("catch cl_new cl_future.");
+  });
+});
+
+describe("class_parser 23, renameLocalType exception in raising", () => {
+  it("something", () => {
+    let oldCode = "raising cl_foo resumable(cl_bar).";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+    expect(newCode).to.equal("raising cl_new resumable(cl_bar).");
+
+    let newCode2 = ClassParser.renameLocalType("cl_bar", "cl_future", "cl_parent", newCode);
+    expect(newCode2).to.equal("raising cl_new resumable(cl_future).");
+  });
+});
+
+describe("class_parser 24, renameLocalType no rename in asterisk comments", () => {
+  it("something", () => {
+    let oldCode = "* The class cl_foo does the hard work";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+
+    expect(newCode).to.equal("* The class cl_foo does the hard work");
+  });
+});
+
+describe("class_parser 25, renameLocalType no rename in double quote comments", () => {
+  it("something", () => {
+    let oldCode = "lo_inst = cl_foo=>instance( ). \" cache singletone inst of cl_foo";
+    let newCode = ClassParser.renameLocalType("cl_foo", "cl_new", "cl_parent", oldCode);
+
+    expect(newCode).to.equal("lo_inst = cl_new=>instance( ). \" cache singletone inst of cl_foo");
+  });
+});
+
+describe("class_parser 26, renameLocalType interfaces in class definition", () => {
+  it("something", () => {
+    let oldCode = "class cl_parent definition.\n  public section.\n    interfaces lif_foo.\n";
+    let newCode = ClassParser.renameLocalType("lif_foo", "lif_renamed", "cl_parent", oldCode);
+
+    expect(newCode).to.equal("class cl_parent definition.\n  public section.\n    interfaces lif_renamed.\n");
+  });
+});
+
+describe("class_parser 27, renameLocalType interface in method implementation", () => {
+  it("something", () => {
+    let oldCode = "class cl_parent implementation.\n  method lif_foo~do.\n  endmethod.\n";
+    let newCode = ClassParser.renameLocalType("lif_foo", "lif_renamed", "cl_parent", oldCode);
+
+    expect(newCode).to.equal("class cl_parent implementation.\n  method lif_renamed~do.\n  endmethod.\n");
+  });
+});
+
+describe("class_parser 28, the method parse ", () => {
+  it("processes all files", () => {
+    let mainFile = new File(
+      "cl_parent.clas.abap",
+      "class cl_parent definition.\n" +
+      "private section.\n" +
+      "data: mo_impl typ ref to lif_impl.\n" +
+      "endclass.\n" +
+      "class cl_parent implementation.\n" +
+      "method constructor.\n" +
+      "mo_impl = cast lif_impl(new lcl_impl_prod( )).\n" +
+      "endmethod.\n" +
+      "endclass.\n");
+
+    let defFile = new File(
+      "cl_parent.clas.locals_def.abap",
+      "interface lif_impl.\nendinterface.\n" +
+      "class lcl_impl_base definition.\n" +
+      "interfaces lif_impl.\n" +
+      "endclass.\n");
+
+    let impFile = new File(
+      "cl_parent.clas.locals_imp.abap",
+      "class lcl_impl_prod definition inheriting from lcl_impl_base.\n" +
+      "public section.\n" +
+      "interfaces lif_impl.\n" +
+      "endclass.\n");
+
+    let files = new FileList();
+
+    files.push(mainFile);
+    files.push(defFile);
+    files.push(impFile);
+
+    let abapClass = ClassParser.parse(mainFile, files);
+
+    expect(abapClass.getDefinition()).to.equal(
+            "class GiiGhQvMEsAOOpdApbtQhfRrLQpNLF DEFINITION DEFERRED.\n" +
+            "interface WboRqQvMEsAOOpdApbtQPWHIIjHuMM DEFERRED.\n" +
+            "* renamed: cl_parent :: lif_impl\n" +
+            "interface WboRqQvMEsAOOpdApbtQPWHIIjHuMM.\n" +
+            "endinterface.\n" +
+            "* renamed: cl_parent :: lcl_impl_base\n" +
+            "class GiiGhQvMEsAOOpdApbtQhfRrLQpNLF definition.\n" +
+            "interfaces WboRqQvMEsAOOpdApbtQPWHIIjHuMM.\n" +
+            "endclass.\n\n" +
+            "class cl_parent definition.\n" +
+            "private section.\n" +
+            "data: mo_impl typ ref to WboRqQvMEsAOOpdApbtQPWHIIjHuMM.\n" +
+            "endclass.");
+
+    expect(abapClass.getImplementation()).to.equal(
+            "class GiiGhQvMEsAOOpdApbtQvMjIdUypid DEFINITION DEFERRED.\n* renamed: cl_parent :: lcl_impl_prod\n" +
+            "class GiiGhQvMEsAOOpdApbtQvMjIdUypid definition inheriting from GiiGhQvMEsAOOpdApbtQhfRrLQpNLF.\n" +
+            "public section.\ninterfaces WboRqQvMEsAOOpdApbtQPWHIIjHuMM.\nendclass.\n\n" +
+            "class cl_parent implementation.\nmethod constructor.\n" +
+            "mo_impl = cast WboRqQvMEsAOOpdApbtQPWHIIjHuMM(new GiiGhQvMEsAOOpdApbtQvMjIdUypid( )).\n" +
+            "endmethod.\nendclass.\n");
+  });
+});


### PR DESCRIPTION
commit 2490c48225e8267119207a03de09323b4d95e609
Author: Jakub Filak <jakub.filak@sap.com>
Date:   Sun Jul 1 00:59:33 2018 +0200

    class: merge local definition & implementation
    
    I create classes with local definitions and implementations which helps
    me to develop unit tests much easier because I can easily mock behaviour
    of private implementation of public classes.
    
    In some of our systems, I am not allowed to create new packages and thus
    I cannot use abapGit deploy my development tools there. However, I can
    create customer space reports, so I needed to teach abapmerge to compile
    my ABAP tools.
    
    Local definitions are placed before public definition and local
    implementations are placed before public implementation.
    
    To avoid name collisions, local type names are converted to random
    strings of 30 characters where:
    - 0-4 : type hash (interface or class)
    - 5-19 : public class name hash
    - 20-29 : local type name hash
    
    Hashes are created as random strings using pseudo random generator where
    its seeds is computed from the name using an algorithm found somewhere in
    the Internet [1]. Also the PRG algorithm should mimic LCG with MINSTD
    parameters [2].
    
    This approach for generating anonymous names should make sure that 
    the generated names stays unchanged between two runs.

    ----
    v2:
    
    @larshp pointed out in the review #53 that we should include mapping to
    the original name and the parent type to simplify problem analysis.
    
    I implemented his idea by prepending a comment with the old name and the
    public class name to declaration statement of the anonymized type.
    
    Example:
    * the original name lcl_def of the public class cl_foo anonymized to
      GiiGhXOXPMwTAnXjaE
    
    ```diff
      - class lcl_def definition.
      + * renamed: cl_foo :: lcl_def
      + class GiiGhXOXPMwTAnXjaE definition.
    ```
    ----
    v3:
    
    My initial idea was to make sure the renaming will affect only correct
    statements by doing simple syntax analysis. I remembered only class
    definition, interface definition and use of a type.
    
    However, there are many more syntax constructions where a type can
    appear:
    
    * exception in catch
    * exception in raising
    * class in inheriting from
    * class in friends
    * class in create object with type
    * interface in interfaces
    * interface in aliases
    * interface in methods
    * interface in method
    * interface in instances access
    
    and I am sure I forgot something.
    
    I found out it is no so easy to parse context grammar by regular
    expressions so I decided to simplify the algorithm to:
    * detect class definition to provide the old type name
    * detect interface definition to provide the old type name
    * rename all occurrences of the old type in non-comment text
    
    Beware that this brute force approach will rename the type occurrences
    in string literals.
    
    ---- 
    
    1: http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
    2: https://en.wikipedia.org/wiki/Lehmer_random_number_generator#Parameters_in_common_use