### PR TITLE
Pragma main +  merge without include

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ Test online: http://larshp.github.io/abapmerge/
 
 * `npm test`
 
+### How it works
+
+abapmerge takes a path to the main report and analyzes its code and all files
+stored in the same directory and all sub-directories.
+
+The resulting code consists of the code of all found ABAP classes and
+interfaces, regardless of their production use in any part of the resulting
+report, and contents of ABAP includes found in the main report or the included
+reports.
+
+abapmerge expects that the whole directory structure should result into a
+single executable program and, hence, if it finds an ABAP report that is not
+directly or indirectly included in the main report, abapmerge terminates its
+processing without issuing the input.
+
+abapmerge requires file naming schema compatible with the schema used by [abapGit](https://github.com/larshp/abapgit/).
+
 ### Additional features
 
 Abapmerge supports pragmas that can be written inside an abap comment. If written as " comment, then indentation before " is also used for output.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Currently supported pragmas:
   - {filename} - path to the file relative to script execution dir (argv[0])
   - {string wrapper} is a pattern where `$$` is replaced by the include line
   - `$$` is escaped - ' replaced to '' (to fit in abap string), use `$$$` to skip escaping
+- **main** void
+  - must be included at the very first line of a ABAP program that should be
+    treated as a standalone main report and abamerge should not die with an error
+    if the program is never included.
 
 Example
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -34,4 +34,16 @@ export default class File {
   public isABAP() {
     return this.filename.match(/.abap$/) !== null;
   }
+
+  public isPROG(): boolean {
+    return this.filename.match(/prog.abap$/) !== null;
+  }
+
+  public isMain(): boolean {
+    if (!this.isPROG()) {
+      return false;
+    }
+
+    return !!this.contents.match(/^(\*|\s*")\s*@@abapmerge\s+main\s+void/i);
+  }
 }

--- a/src/file_list.ts
+++ b/src/file_list.ts
@@ -52,7 +52,7 @@ export default class FileList {
 
   public checkFiles(): void {
     const unusedFiles = this.files
-      .filter(i => !i.wasUsed() && i.isABAP())
+      .filter(i => !i.wasUsed() && (i.isABAP() && !i.isMain()))
       .map(i => i.getFilename().toLowerCase())
       .join(", ");
 

--- a/src/pragma.ts
+++ b/src/pragma.ts
@@ -22,7 +22,7 @@ export default class Pragma {
         if (pragma) {
           let indent = (pragma[1] === "*") ? "" : pragma[2];
           let presult = this.processPragma(indent, pragma[3]);
-          if (result) {
+          if (presult) {
             output += presult + "\n";
           } else {
             output += line + "\n";

--- a/test/test.ts
+++ b/test/test.ts
@@ -290,3 +290,27 @@ describe("test 17, included classes are placed after whitespace and comments", (
     expect(result.substr(0, exp.length)).to.equal(exp);
   });
 });
+
+describe("test 18, @@abapmerge w/ main no failure", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain.abap", "REPORT zmain.\n\nINCLUDE zinc1."));
+    files.push(new File("zmain2.prog.abap", "\" @@abapmerge main void\n" +
+                                            "REPORT zmain2.\n\nINCLUDE zinc1."));
+    files.push(new File("zinc1.abap", "write / 'foo'."));
+
+    let result = Merge.merge(files, "zmain");
+    expect(result).to.be.a("string");
+  });
+});
+
+describe("test 19, @@abapmerge w/o main causes failure", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain.abap", "REPORT zmain.\n\nINCLUDE zinc1."));
+    files.push(new File("zmain2.prog.abap", "REPORT zmain2.\n\nINCLUDE zinc1."));
+    files.push(new File("zinc1.abap", "write / 'foo'."));
+
+    expect(Merge.merge.bind(Merge, files, "zmain")).to.throw("Not all files used: [zmain2.prog.abap]");
+  });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -135,10 +135,10 @@ describe("test 11, simple class", () => {
                "CLASS zcl_class IMPLEMENTATION.\n" +
                "  METHOD blah.\n" +
                "  ENDMETHOD.\n" +
-               "ENDCLASS."));
+               "ENDCLASS.\n"));
     let result = Merge.merge(files, "zmain");
     expect(result).to.be.a("string");
-    expect(result.split("\n").length).to.equal(21);
+    expect(result.split("\n").length).to.equal(20);
   });
 });
 
@@ -172,5 +172,121 @@ describe("test 13, skip function groups", () => {
     files.push(new File("zmain.abap", "REPORT zmain."));
     files.push(new File("zabapgit_unit_te.fugr.saplzabapgit_unit_te.abap", "WRITE / 'Hello World!'."));
     expect(Merge.merge(files, "zmain")).to.be.a("string");
+  });
+});
+
+describe("test 14, include classes event without INCLUDE", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain13.prog.abap", "REPORT zmain13.\n" +
+                                             "\n" +
+                                             "write: 'Hello, world!'.\n"));
+    files.push(new File("zcl_main.clas.abap", "class zcl_main defintion.\n" +
+                                              "endclass.\n" +
+                                              "class zcl_main implementation.\n" +
+                                              "endclass.\n"));
+
+    const exp = "REPORT zmain13.\n" +
+      "\n" +
+      "CLASS zcl_main DEFINITION DEFERRED.\n" +
+      "class zcl_main defintion.\n" +
+      "endclass.\n" +
+      "class zcl_main implementation.\n" +
+      "endclass.\n" +
+      "write: 'Hello, world!'.\n" +
+      "****************************************************\n";
+
+    let result = Merge.merge(files, "zmain13");
+
+    expect(result.substr(0, exp.length)).to.equal(exp);
+  });
+});
+
+describe("test 15, included classes are placed after whitespace and comments", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain13.prog.abap", "REPORT zmain13.\n" +
+                                             "* Comment asterisk\n" +
+                                             "write: 'Hello, world!'.\n"));
+
+    files.push(new File("zcl_main.clas.abap", "class zcl_main defintion.\n" +
+                                              "endclass.\n" +
+                                              "class zcl_main implementation.\n" +
+                                              "endclass.\n"));
+
+    const exp = "REPORT zmain13.\n" +
+      "* Comment asterisk\n" +
+      "CLASS zcl_main DEFINITION DEFERRED.\n" +
+      "class zcl_main defintion.\n" +
+      "endclass.\n" +
+      "class zcl_main implementation.\n" +
+      "endclass.\n" +
+      "write: 'Hello, world!'.\n" +
+      "****************************************************\n";
+
+    let result = Merge.merge(files, "zmain13");
+
+    expect(result.substr(0, exp.length)).to.equal(exp);
+  });
+});
+
+describe("test 16, REPORT with LINE-SIZE", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain14.prog.abap", "REPORT zmain14 LINE-SIZE 100.\n" +
+                                           "\n" +
+                                           "write: 'Hello, world!'.\n"));
+    files.push(new File("zcl_main.clas.abap", "class zcl_main defintion.\n" +
+                                              "endclass.\n" +
+                                              "class zcl_main implementation.\n" +
+                                              "endclass.\n"));
+
+    const exp = "REPORT zmain14 LINE-SIZE 100.\n" +
+      "\n" +
+      "CLASS zcl_main DEFINITION DEFERRED.\n" +
+      "class zcl_main defintion.\n" +
+      "endclass.\n" +
+      "class zcl_main implementation.\n" +
+      "endclass.\n" +
+      "write: 'Hello, world!'.\n" +
+      "****************************************************\n";
+
+    let result = Merge.merge(files, "zmain14");
+
+    expect(result.substr(0, exp.length)).to.equal(exp);
+  });
+});
+
+describe("test 17, included classes are placed after whitespace and comments", () => {
+  it("something", () => {
+    let files = new FileList();
+    files.push(new File("zmain17.prog.abap", "REPORT zmain17 LINE-SIZE 100.\n" +
+                                             "\n" +
+                                             "* Comment asterisk\n" +
+                                             "* Epic success!\n" +
+                                             "\n" +
+                                             "write: 'Hello, world!'.\n"));
+
+    files.push(new File("zcl_main.clas.abap", "class zcl_main defintion.\n" +
+                                              "endclass.\n" +
+                                              "class zcl_main implementation.\n" +
+                                              "endclass.\n"));
+
+    const exp = "REPORT zmain17 LINE-SIZE 100.\n" +
+      "\n" +
+      "* Comment asterisk\n" +
+      "* Epic success!\n" +
+      "\n" +
+      "CLASS zcl_main DEFINITION DEFERRED.\n" +
+      "class zcl_main defintion.\n" +
+      "endclass.\n" +
+      "class zcl_main implementation.\n" +
+      "endclass.\n" +
+      "write: 'Hello, world!'.\n" +
+      "****************************************************\n";
+
+    let result = Merge.merge(files, "zmain17");
+
+    expect(result.substr(0, exp.length)).to.equal(exp);
   });
 });


### PR DESCRIPTION
commit 0feb42c1dff1c02569d861dae773915f54c53ab2
Author: Jakub Filak <jakub.filak@sap.com>
Date:   Sun Jul 1 01:16:50 2018 +0200

    merge: include classes even if there is no INCLUDE statement
    
    I create reports that just do not include any other report but use a
    class infrastructure I created in the package. I am not sure it is the
    good approach how to develop ABAP reports but it works for me.
    
    I decided to change the logic of merge which includes public classes
    before the first INCLUDE statement in the way that public classes
    are included right after the REPORT statement.
    
    The old approach did not included any class to my reports because in
    there is no INCLUDE statement in my reports.
    
    To be honest, I am not sure what was the reason behind including public
    classes before the first INCLUDE statement and not earlier.
    
    Therefore, I consider this commit DANGEROUS.
    
    If this approach does not work, I propose to define a new pragma.

commit 882abd7cbbb76a005ac2c5486e6457875254bdb8
Author: Jakub Filak <jakub.filak@sap.com>
Date:   Sun Jul 1 11:27:53 2018 +0200

    pragma: fix a typo in result processing
    
    I believe we should check the variable presult and not the variable
    result, because when a pragma has no result we should not try to add the
    nothing into the total result.
    
    However, I am not even sure we should copy the pragma's definition into
    result in the case where the pragma has no outcome. But I didn't remove
    those statements as the pragma line can help users to figure out
    problems.

commit 4e0fef55597cb9f08cbc86acd535a915c491bcb0
Author: Jakub Filak <jakub.filak@sap.com>
Date:   Sun Jul 1 01:01:22 2018 +0200

    pragma: add main to denote main reports
    
    I develop reports based on one class infrastructure but the reporst do
    different things (Unix philosophy). I create these reports in one
    development package.
    
    When I tried to generate a compiled report using abapmerge, I got an
    error saying that not all files were used. That's good but in my case
    the files are not used intentionally.
    
    I decided to introduce a new pragma called 'main' with a single
    parameter 'void' (static literal - because I have no ambitions to
    rewrite the pragma system in the way we can have a pragma without
    parameters).
    
    This new pragma allows me to opt-out from the 'all-files-used' check,
    while it preserves the check for all other users.
