### PR TITLE
Command line opts improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ output.abap
 coverage
 .nyc_output
 .vscode/
+dummy*.abap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12"
+  - "10"
 notifications:
   email: false
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,10 +490,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
+      "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2002,6 +2001,12 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
         "diff": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "mocha": "^6.0.2",
     "tslint": "^5.13.1",
     "typescript": "^3.3.3333"
+  },
+  "dependencies": {
+    "commander": "^3.0.1"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,15 @@ import * as path from "path";
 import File from "./file";
 import FileList from "./file_list";
 import Merge from "./merge";
+import commander from "commander";
+import PackageInfo from "../package.json";
+
+interface ICliArgs {
+  entryFilename: string;
+  entryObjectName: string;
+  entryDir: string;
+  skipFUGR: boolean;
+}
 
 class Logic {
   private static textFiles = new Set([".abap", ".xml", ".css", ".js"]);
@@ -32,28 +41,35 @@ class Logic {
     return list;
   }
 
-  public static parseArgs(): {main: string, dir: string, skipFUGR: boolean} {
-    let arg = process.argv.slice(2);
-    let skipFUGR = false;
+  public static parseArgs(): ICliArgs {
 
-    if (arg.length === 0) {
-      throw new Error("Supply filename");
+    commander
+      .description(PackageInfo.description)
+      .version(PackageInfo.version)
+      .option("-f, --skip-fugr", "ignore unused function groups", false)
+      .arguments("<entrypoint>");
+    commander.parse(process.argv);
+
+    if (!commander.args.length) {
+      throw Error("Specify entrypoint file name");
+    } else if (commander.args.length > 1) {
+      throw Error("Specify just one entrypoint");
     }
 
-    let index = arg.indexOf("-f");
-    if (index >= 0) {
-      skipFUGR = true;
-      arg.splice(index, 1);
+    const entrypoint = commander.args[0];
+    if (!fs.existsSync(entrypoint)) {
+      throw new Error(`File "${entrypoint}" does not exist`);
     }
 
-    if (!fs.existsSync(arg[0])) {
-      throw new Error(`File ${path} does not exist`);
-    }
+    let entryDir = path.dirname(entrypoint);
+    let entryFilename = path.basename(entrypoint);
 
-    let dir = path.dirname(arg[0]);
-    let main = path.basename(arg[0]);
-
-    return {main, dir, skipFUGR};
+    return {
+      entryDir,
+      entryFilename,
+      entryObjectName: entryFilename.split(".")[0],
+      skipFUGR: commander.skipFugr,
+    };
   }
 
   public static run() {
@@ -61,8 +77,7 @@ class Logic {
     let output = "";
     try {
       const parsedArgs = Logic.parseArgs();
-      const entryPoint = parsedArgs.main.split(".")[0];
-      output = Merge.merge(Logic.readFiles(parsedArgs.dir), entryPoint, {skipFUGR: parsedArgs.skipFUGR});
+      output = Merge.merge(Logic.readFiles(parsedArgs.entryDir), parsedArgs.entryObjectName, { skipFUGR: parsedArgs.skipFUGR });
       output = Merge.appendFooter(output);
       process.stdout.write(output);
     } catch (e) {
@@ -70,7 +85,7 @@ class Logic {
       retval = 1;
       process.stderr.write(output);
     }
-    if (output === undefined) { throw new Error("output undefined, hmm?"); }
+    if (output === undefined) throw new Error("output undefined, hmm?");
     return retval;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,7 +78,7 @@ class Logic {
     try {
       const parsedArgs = Logic.parseArgs();
       output = Merge.merge(Logic.readFiles(parsedArgs.entryDir), parsedArgs.entryObjectName, { skipFUGR: parsedArgs.skipFUGR });
-      output = Merge.appendFooter(output);
+      output = Merge.appendFooter(output, PackageInfo.version);
       process.stdout.write(output);
     } catch (e) {
       output = e.message ? e.message : e;

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -19,13 +19,13 @@ export default class Merge {
     return result;
   }
 
-  public static appendFooter(contents: string) {
+  public static appendFooter(contents: string, version: string): string {
     return contents +
       "****************************************************\n" +
       "INTERFACE lif_abapmerge_marker.\n" +
       "ENDINTERFACE.\n" +
       "****************************************************\n" +
-      "* abapmerge " + process.env.npm_package_version + " - " + new Date().toJSON() + "\n" +
+      "* abapmerge " + version + " - " + new Date().toJSON() + "\n" +
       "****************************************************\n";
   }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -332,7 +332,7 @@ describe("test 20, include abapmerge version number in footer", () => {
     files.push(new File("zinc1.abap", "write / 'foo'."));
 
     let result = Merge.merge(files, "zmain");
-    result = Merge.appendFooter(result);
+    result = Merge.appendFooter(result, "1.0.0");
     expect(result).to.match(/\* abapmerge (?:(\d+\.[.\d]*\d+))/);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
         "noUnusedParameters": true,
         "noUnusedLocals": true,
         "sourceMap": true,
-        "downlevelIteration": true
+        "downlevelIteration": true,
+        "esModuleInterop": true,
+        "resolveJsonModule": true
         },
     "filesGlob": [
         "./**/*.ts"


### PR DESCRIPTION
Propose to use commander.js for command line parsing - a very good library, zero dependencies, clean syntax, auto support for help and version, well really good one. Also [community votes](https://www.npmtrends.com/commander-vs-minimist-vs-optimist-vs-optionator-vs-yargs) :)

should be merged after #90: for now the diff can be viewed here: https://github.com/sbcgua/abapmerge/compare/commandimprovements...sbcgua:commandline-improvements?expand=1

So now:
- `-h, --help` outputs help
- `-V, --version` outputs vevrsion
- everything else is the same actually
- plus bugfix in the footer if run without npm (process.env.npm_package_version was not available)