### PR TITLE
New pragma: "include-cua"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,27 @@ Merge ABAP INCLUDEs into single file. Function groups are skipped
 
 ## Building
 
-* `npm install`
-* `npm test`
+- `npm install`
+- `npm test`
+- `abapmerge -h` - to see the parameters
+
+## Invocation example
+
+Take `src/zabapgit.prog.abap`, merge it, rename the program (`report` statement) to `zabapgit_standalone` and save to `zabapgit.abap` in the current directory.
+
+- `abapmerge -f src/zabapgit.prog.abap -c zabapgit_standalone -o zabapgit.abap`
 
 ## How it works
 
-abapmerge takes a path to the main report and analyzes its code and all files stored in the same directory and all sub-directories.
+Abapmerge takes a path to the main report and analyzes its code and all files stored in the same directory and all sub-directories.
 
 The resulting code consists of the code of all found ABAP classes and interfaces, regardless of their production use in any part of the resulting report, and contents of ABAP includes found in the main report or the included reports.
 
-abapmerge expects that the whole directory structure should result into a single executable program and, hence, if it finds an ABAP report that is not directly or indirectly included in the main report, abapmerge terminates its processing without issuing the input.
+Abapmerge expects that the whole directory structure should result into a single executable program and, hence, if it finds an ABAP report that is not directly or indirectly included in the main report, abapmerge terminates its processing without issuing the input.
 
-abapmerge requires file naming schema compatible with the schema used by [abapGit](https://github.com/larshp/abapgit/).
+Abapmerge requires file naming schema compatible with the schema used by [abapGit](https://github.com/larshp/abapgit).
 
-Global classes FOR TESTING are skipped.
+Global classes `FOR TESTING` are skipped.
 
 ## Pragmas
 
@@ -39,7 +46,7 @@ Currently supported pragmas:
 - **main** void
   - must be included at the very first line of a ABAP program that should be treated as a standalone main report and abamerge should not die with an error if the program is never included.
 
-### Example
+### Examples
 
 ```abap
 ...

--- a/README.md
+++ b/README.md
@@ -4,32 +4,24 @@
 
 Merge ABAP INCLUDEs into single file. Function groups are skipped
 
-### Building
+## Building
 
 * `npm install`
-
 * `npm test`
 
-### How it works
+## How it works
 
-abapmerge takes a path to the main report and analyzes its code and all files
-stored in the same directory and all sub-directories.
+abapmerge takes a path to the main report and analyzes its code and all files stored in the same directory and all sub-directories.
 
-The resulting code consists of the code of all found ABAP classes and
-interfaces, regardless of their production use in any part of the resulting
-report, and contents of ABAP includes found in the main report or the included
-reports.
+The resulting code consists of the code of all found ABAP classes and interfaces, regardless of their production use in any part of the resulting report, and contents of ABAP includes found in the main report or the included reports.
 
-abapmerge expects that the whole directory structure should result into a
-single executable program and, hence, if it finds an ABAP report that is not
-directly or indirectly included in the main report, abapmerge terminates its
-processing without issuing the input.
+abapmerge expects that the whole directory structure should result into a single executable program and, hence, if it finds an ABAP report that is not directly or indirectly included in the main report, abapmerge terminates its processing without issuing the input.
 
 abapmerge requires file naming schema compatible with the schema used by [abapGit](https://github.com/larshp/abapgit/).
 
 Global classes FOR TESTING are skipped.
 
-### Additional features
+## Pragmas
 
 Abapmerge supports pragmas that can be written inside an abap comment. If written as " comment, then indentation before " is also used for output.
 
@@ -40,15 +32,18 @@ Currently supported pragmas:
   - {filename} - path to the file relative to script execution dir (argv[0])
   - {string wrapper} is a pattern where `$$` is replaced by the include line
   - `$$` is escaped - ' replaced to '' (to fit in abap string), use `$$$` to skip escaping
+- **include-base64** {filename} > {string wrapper}
+  - same is `include` just that the data is encoded to base64, supposedly the data is binary.
+- **include-cua** {filename.xml} > {variable}
+  - reads XML, presumably a serialized PROG/FUGR, and extracts GUI status (CUA) node from it. Then use it to fill `variable`. The `variable` is supposed to be of `zcl_abapgit_objects_program=>ty_cua` type. Required data definitions are also generated e.g. `'DATA ls_adm LIKE variable-adm'`.
 - **main** void
-  - must be included at the very first line of a ABAP program that should be
-    treated as a standalone main report and abamerge should not die with an error
-    if the program is never included.
+  - must be included at the very first line of a ABAP program that should be treated as a standalone main report and abamerge should not die with an error if the program is never included.
 
-Example
+### Example
 
 ```abap
 ...
   " @@abapmerge include somefile.txt > APPEND '$$' TO styletab.
+  " @@abapmerge include-cua abapgit.prog.xml > ls_cua
 ...
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.14.9",
       "license": "MIT",
       "dependencies": {
-        "commander": "^10.0.0"
+        "commander": "^10.0.0",
+        "fast-xml-parser": "^4.1.3"
       },
       "bin": {
         "abapmerge": "abapmerge"
@@ -1158,6 +1159,21 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.3.tgz",
+      "integrity": "sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2236,6 +2252,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3420,6 +3441,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.3.tgz",
+      "integrity": "sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4189,6 +4218,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "commander": "^10.0.0"
+    "commander": "^10.0.0",
+    "fast-xml-parser": "^4.1.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ interface ICliArgs {
   skipFUGR: boolean;
   noFooter: boolean;
   newReportName: string;
+  outputFile: string;
 }
 
 export class Logic {
@@ -55,6 +56,7 @@ export class Logic {
       .description(PackageInfo.description)
       .version(PackageInfo.version)
       .option("-f, --skip-fugr", "ignore unused function groups", false)
+      .option("-o, --output <file>", "output to a file (instead of stdout)")
       .option("--without-footer", "do not append footers", false)
       .option(
         "-c, --change-report-name <newreportname>",
@@ -87,6 +89,7 @@ export class Logic {
       skipFUGR: cmdOpts.skipFugr,
       noFooter: cmdOpts.withoutFooter,
       newReportName: cmdOpts.changeReportName,
+      outputFile: cmdOpts.output,
     };
   }
 
@@ -109,7 +112,11 @@ export class Logic {
           appendAbapmergeMarker: parsedArgs.noFooter === false,
         },
       );
-      process.stdout.write(output);
+      if (parsedArgs.outputFile) {
+        fs.writeFileSync(parsedArgs.outputFile, output, "utf-8");
+      } else {
+        process.stdout.write(output);
+      }
       if (output === undefined) throw new Error("output undefined, hmm?");
       return 0;
     } catch (e) {

--- a/src/pragma.ts
+++ b/src/pragma.ts
@@ -1,7 +1,6 @@
 import FileList from "./file_list";
 import File from "./file";
 import { XMLParser } from "fast-xml-parser";
-import { off } from 'process';
 
 export interface IPragmaOpts {
   noComments?: boolean;

--- a/src/pragma.ts
+++ b/src/pragma.ts
@@ -9,6 +9,7 @@ export interface IPragmaOpts {
 export default class PragmaProcessor {
   private files: FileList;
   private opts: IPragmaOpts;
+  private currentPragmaName: string;
 
   public static process(files: FileList, opts?: IPragmaOpts): FileList {
     const instance = new PragmaProcessor(files, opts);
@@ -63,7 +64,7 @@ export default class PragmaProcessor {
       ? []
       : [
         "****************************************************",
-        "* abapmerge Pragma - " + name.toUpperCase(),
+        `* abapmerge Pragma [${this.currentPragmaName}] - ${name.toUpperCase()}`,
         "****************************************************",
       ];
   }
@@ -90,6 +91,7 @@ export default class PragmaProcessor {
     const command = cmdMatch[1].toLowerCase();
     const commandParams = cmdMatch[2];
 
+    this.currentPragmaName = command; // hack for `comment()`
     switch (command) {
       case "include":
         result.push(...this.pragmaInclude(indent, commandParams));

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -38,6 +38,7 @@ describe("CLI parse arguments", () => {
       skipFUGR: false,
       noFooter: false,
       newReportName: undefined,
+      outputFile: undefined,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -53,6 +54,7 @@ describe("CLI parse arguments", () => {
       skipFUGR: true,
       noFooter: false,
       newReportName: undefined,
+      outputFile: undefined,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -69,6 +71,7 @@ describe("CLI parse arguments", () => {
       skipFUGR: true,
       noFooter: true,
       newReportName: undefined,
+      outputFile: undefined,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -87,6 +90,24 @@ describe("CLI parse arguments", () => {
       skipFUGR: true,
       noFooter: true,
       newReportName: "znewname",
+      outputFile: undefined,
+    };
+    chai.assert.isNotNull(parsedArgs);
+    chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
+  });
+
+  it("outputFile option", () => {
+    args.push("-o");
+    args.push("some.file");
+    args.push(join(__dirname, "entry.abap"));
+    let parsedArgs = Logic.parseArgs(args);
+    let parsedArgsExpected = {
+      entryDir: __dirname,
+      entryFilename: "entry.abap",
+      skipFUGR: false,
+      noFooter: false,
+      newReportName: undefined,
+      outputFile: "some.file",
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);

--- a/test/pragmas.ts
+++ b/test/pragmas.ts
@@ -66,4 +66,72 @@ describe("Pragma include", () => {
     const inc = newList.get(1);
     expect(inc.wasUsed()).to.equal(true);
   });
+
+  it("include a cua from XML", () => {
+    let files = buildFileList({
+      "zmain.abap": [
+        "REPORT zmain.",
+        "  DATA ls_cua TYPE ty_cua.",
+        "  \" @@abapmerge include-cua some.xml > ls_cua",
+      ],
+      "some.xml": `
+      <?xml version="1.0" encoding="utf-8"?>
+      <abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+       <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+        <asx:values>
+          <PROGDIR>
+            <NAME>SOME</NAME>
+          </PROGDIR>
+          <CUA>
+            <ADM>
+              <PFKCODE>000001</PFKCODE>
+            </ADM>
+            <STA>
+              <RSMPE_STAT>
+                <CODE>DECIDE_DIALOG</CODE>
+                <MODAL>P</MODAL>
+              </RSMPE_STAT>
+            </STA>
+            <FUN>
+              <RSMPE_FUNT>
+                <CODE>CANCEL</CODE>
+                <TEXTNO>001</TEXTNO>
+              </RSMPE_FUNT>
+              <RSMPE_FUNT>
+                <CODE>OK</CODE>
+                <TEXTNO>002</TEXTNO>
+              </RSMPE_FUNT>         
+            </FUN>
+         </CUA>
+        </asx:values>
+       </asx:abap>
+      </abapGit>
+      `,
+    });
+
+    const newList = PragmaProcessor.process(files, { noComments: true });
+    expect(newList.length()).to.equal(2);
+
+    const main = newList.get(0);
+
+    expect(main.getContents()).to.equal(`
+      REPORT zmain.
+        DATA ls_cua TYPE ty_cua.
+        ls_cua-adm-pfkcode = '000001'.
+        DATA ls_sta TYPE rsmpe_stat.
+        ls_sta-code = 'DECIDE_DIALOG'.
+        ls_sta-modal = 'P'.
+        append ls_sta to ls_cua-sta.
+        DATA ls_fun TYPE rsmpe_funt.
+        ls_fun-code = 'CANCEL'.
+        ls_fun-textno = '001'.
+        append ls_fun to ls_cua-fun.
+        ls_fun-code = 'OK'.
+        ls_fun-textno = '002'.
+        append ls_fun to ls_cua-fun.
+    `);
+
+    const inc = newList.get(1);
+    expect(inc.wasUsed()).to.equal(true);
+  });
 });

--- a/test/pragmas.ts
+++ b/test/pragmas.ts
@@ -138,4 +138,33 @@ describe("Pragma include", () => {
     const inc = newList.get(1);
     expect(inc.wasUsed()).to.equal(true);
   });
+
+  it("include a cua from XML, negative", () => {
+    let files = buildFileList({
+      "zmain.abap": `
+        REPORT zmain.
+          " @@abapmerge include-cua some.xml > ls_cua
+      `.trim().split("\n"),
+      "some.xml": `
+        <?xml version="1.0" encoding="utf-8"?>
+        <abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+        <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+          <asx:values>
+            <CUA>
+              <ADM>
+                <PFKCODE>000001</PFKCODE>
+              </ADM>
+              <STA>
+                <CODE>DECIDE_DIALOG</CODE>
+                <MODAL>P</MODAL>
+              </STA>
+          </CUA>
+          </asx:values>
+        </asx:abap>
+        </abapGit>
+      `,
+    });
+
+    expect(() => PragmaProcessor.process(files, { noComments: true })).to.throw();
+  });
 });

--- a/test/pragmas.ts
+++ b/test/pragmas.ts
@@ -69,43 +69,43 @@ describe("Pragma include", () => {
 
   it("include a cua from XML", () => {
     let files = buildFileList({
-      "zmain.abap": [
-        "REPORT zmain.",
-        "  DATA ls_cua TYPE ty_cua.",
-        "  \" @@abapmerge include-cua some.xml > ls_cua",
-      ],
+      "zmain.abap": `
+        REPORT zmain.
+          DATA ls_cua TYPE ty_cua.
+          " @@abapmerge include-cua some.xml > ls_cua
+      `.trim().split("\n"),
       "some.xml": `
-      <?xml version="1.0" encoding="utf-8"?>
-      <abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
-       <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
-        <asx:values>
-          <PROGDIR>
-            <NAME>SOME</NAME>
-          </PROGDIR>
-          <CUA>
-            <ADM>
-              <PFKCODE>000001</PFKCODE>
-            </ADM>
-            <STA>
-              <RSMPE_STAT>
-                <CODE>DECIDE_DIALOG</CODE>
-                <MODAL>P</MODAL>
-              </RSMPE_STAT>
-            </STA>
-            <FUN>
-              <RSMPE_FUNT>
-                <CODE>CANCEL</CODE>
-                <TEXTNO>001</TEXTNO>
-              </RSMPE_FUNT>
-              <RSMPE_FUNT>
-                <CODE>OK</CODE>
-                <TEXTNO>002</TEXTNO>
-              </RSMPE_FUNT>         
-            </FUN>
-         </CUA>
-        </asx:values>
-       </asx:abap>
-      </abapGit>
+        <?xml version="1.0" encoding="utf-8"?>
+        <abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+        <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+          <asx:values>
+            <PROGDIR>
+              <NAME>SOME</NAME>
+            </PROGDIR>
+            <CUA>
+              <ADM>
+                <PFKCODE>000001</PFKCODE>
+              </ADM>
+              <STA>
+                <RSMPE_STAT>
+                  <CODE>DECIDE_DIALOG</CODE>
+                  <MODAL>P</MODAL>
+                </RSMPE_STAT>
+              </STA>
+              <FUN>
+                <RSMPE_FUNT>
+                  <CODE>CANCEL</CODE>
+                  <TEXTNO>001</TEXTNO>
+                </RSMPE_FUNT>
+                <RSMPE_FUNT>
+                  <CODE>OK</CODE>
+                  <TEXTNO>002</TEXTNO>
+                </RSMPE_FUNT>         
+              </FUN>
+          </CUA>
+          </asx:values>
+        </asx:abap>
+        </abapGit>
       `,
     });
 
@@ -114,22 +114,26 @@ describe("Pragma include", () => {
 
     const main = newList.get(0);
 
+    // Keep the indentation ! (to match the files above)
     expect(main.getContents()).to.equal(`
-      REPORT zmain.
-        DATA ls_cua TYPE ty_cua.
-        DATA ls_sta LIKE LINE OF ls_cua-sta.
-        DATA ls_fun LIKE LINE OF ls_cua-fun.
-        ls_cua-adm-pfkcode = '000001'.
-        ls_sta-code = 'DECIDE_DIALOG'.
-        ls_sta-modal = 'P'.
-        append ls_sta to ls_cua-sta.
-        ls_fun-code = 'CANCEL'.
-        ls_fun-textno = '001'.
-        append ls_fun to ls_cua-fun.
-        ls_fun-code = 'OK'.
-        ls_fun-textno = '002'.
-        append ls_fun to ls_cua-fun.
-    `);
+        REPORT zmain.
+          DATA ls_cua TYPE ty_cua.
+          DATA ls_sta LIKE LINE OF ls_cua-sta.
+          DATA ls_fun LIKE LINE OF ls_cua-fun.
+          ls_cua-adm-pfkcode = '000001'.
+          CLEAR ls_sta.
+          ls_sta-code = 'DECIDE_DIALOG'.
+          ls_sta-modal = 'P'.
+          APPEND ls_sta TO ls_cua-sta.
+          CLEAR ls_fun.
+          ls_fun-code = 'CANCEL'.
+          ls_fun-textno = '001'.
+          APPEND ls_fun TO ls_cua-fun.
+          CLEAR ls_fun.
+          ls_fun-code = 'OK'.
+          ls_fun-textno = '002'.
+          APPEND ls_fun TO ls_cua-fun.
+    `.trim());
 
     const inc = newList.get(1);
     expect(inc.wasUsed()).to.equal(true);

--- a/test/pragmas.ts
+++ b/test/pragmas.ts
@@ -117,12 +117,12 @@ describe("Pragma include", () => {
     expect(main.getContents()).to.equal(`
       REPORT zmain.
         DATA ls_cua TYPE ty_cua.
+        DATA ls_sta LIKE LINE OF ls_cua-sta.
+        DATA ls_fun LIKE LINE OF ls_cua-fun.
         ls_cua-adm-pfkcode = '000001'.
-        DATA ls_sta TYPE rsmpe_stat.
         ls_sta-code = 'DECIDE_DIALOG'.
         ls_sta-modal = 'P'.
         append ls_sta to ls_cua-sta.
-        DATA ls_fun TYPE rsmpe_funt.
         ls_fun-code = 'CANCEL'.
         ls_fun-textno = '001'.
         append ls_fun to ls_cua-fun.


### PR DESCRIPTION
- to support https://github.com/abapGit/abapGit/pull/6093
- main idea: [unit test with the produced code](https://github.com/larshp/abapmerge/pull/366/files#diff-c95980150b35142be9e220ba5570c682775abadbed72f10a212dd2b950d76f80)
- to fit here: [local class of persistence migrate](https://github.com/abapGit/abapGit/pull/6093/files#diff-2e44c5d755f8088b1c53ed05735bb18880ac477c8398a8b1e89cad251a56f510R66)
- see also changed docs (readme)

Just by the way:
- added `-o` arg, to save to a file instead of stdout. Useful at least for using stderr for debug
- better pragma comment (includes pragma name)
