### PR TITLE
Add constants to marker interface

### DIFF
--- a/src/abapmerge_marker.ts
+++ b/src/abapmerge_marker.ts
@@ -2,10 +2,15 @@ import PackageInfo from "../package.json";
 
 export default class AbapmergeMarker {
   public render(): string {
+    const timestamp = new Date().toJson();
+    const abapmergeVersion = PackageInfo.version;
+    
     return `
 ****************************************************
 INTERFACE lif_abapmerge_marker.
-* abapmerge ${ PackageInfo.version } - ${ new Date().toJSON() }
+* abapmerge ${ abapmergeVersion } - ${ timestamp }
+  CONSTANTS c_merge_timestamp TYPE string VALUE \`{ timestamp }\`.
+  CONSTANTS c_abapmerge_version TYPE string VALUE \`{ abapmergeVersion }\`.
 ENDINTERFACE.
 ****************************************************
 `;

--- a/src/abapmerge_marker.ts
+++ b/src/abapmerge_marker.ts
@@ -2,15 +2,15 @@ import PackageInfo from "../package.json";
 
 export default class AbapmergeMarker {
   public render(): string {
-    const timestamp = new Date().toJson();
+    const timestamp = new Date().toJSON();
     const abapmergeVersion = PackageInfo.version;
-    
+
     return `
 ****************************************************
 INTERFACE lif_abapmerge_marker.
 * abapmerge ${ abapmergeVersion } - ${ timestamp }
-  CONSTANTS c_merge_timestamp TYPE string VALUE \`{ timestamp }\`.
-  CONSTANTS c_abapmerge_version TYPE string VALUE \`{ abapmergeVersion }\`.
+  CONSTANTS c_merge_timestamp TYPE string VALUE \`${ timestamp }\`.
+  CONSTANTS c_abapmerge_version TYPE string VALUE \`${ abapmergeVersion }\`.
 ENDINTERFACE.
 ****************************************************
 `;


### PR DESCRIPTION
This change makes it look as follows.

```abap
****************************************************
INTERFACE lif_abapmerge_marker.
* abapmerge 0.15.0 - 2023-06-15T05:52:46.446Z
  CONSTANTS c_merge_timestamp TYPE string VALUE `2023-06-15T05:52:46.446Z`.
  CONSTANTS c_abapmerge_version TYPE string VALUE `0.15.0`.
ENDINTERFACE.
****************************************************
```

Or is there a new configuration option needed to turn this on / off?

Fixes #373