### PR TITLE
wip: resolve pargmas as Pre-Processor

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,14 +1,20 @@
+import * as path from "path";
+
 type FileContent = string | Buffer;
 export default class File {
   private filename: string;
+  private dirname: string;
   private contents: FileContent;
   private isUsed: boolean = false;
+  private modified: boolean = false;
 
   // object names are unique across packages in ABAP, so
   // the folder name is not part of this class
-  public constructor(filename: string, content: FileContent) {
-    this.filename = filename;
+  public constructor(filename: string, content: FileContent, modified?: boolean) {
+    this.dirname = path.dirname(filename);
+    this.filename = path.basename(filename);
     this.contents = content;
+    this.modified = modified;
   }
 
   public isBinary(): boolean {
@@ -23,6 +29,10 @@ export default class File {
     return this.filename;
   }
 
+  public getFilepath(): string {
+    return path.join(this.dirname, this.filename);
+  }
+
   public getContents(): string {
     if (this.isBinary()) throw Error(`Binary file accessed as string [${this.filename}]`);
     return this.contents as string;
@@ -35,6 +45,10 @@ export default class File {
 
   public wasUsed(): boolean {
     return this.isUsed;
+  }
+
+  public isModified(): boolean {
+    return this.modified;
   }
 
   public markUsed() {

--- a/src/file_list.ts
+++ b/src/file_list.ts
@@ -33,18 +33,18 @@ export default class FileList implements Iterable<File> {
       return file;
     }
 
-    throw Error(`file not found: ${name}`);
+    throw Error(`ABAP file not found: ${name}`);
   }
 
   public otherByName(name: string): File {
     name = name.toLowerCase();
-    const file = this.files.find(f => f.getFilename().toLowerCase() === name.toLowerCase() && !f.isABAP());
+    const file = this.files.find(f => (f.getFilename().toLowerCase() === name.toLowerCase() || f.getFilepath().toLowerCase() === name.toLowerCase()) && !f.isABAP());
     if (file) {
       file.markUsed();
       return file;
     }
 
-    throw Error(`file not found: ${name}`);
+    throw Error(`Other file not found: ${name}`);
   }
 
   public validateAllFilesUsed(): void {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -7,18 +7,30 @@ export default class Merge {
   private static files: FileList;
   private static classes: ClassList;
 
+  public static preProcessFiles(files: FileList, options?: {
+    skipFUGR?: boolean;
+  }): FileList {
+    if (!options) options = {};
+
+    let preProcessedFiles = files;
+    if (options.skipFUGR) {
+      preProcessedFiles = this.skipFUGR(preProcessedFiles);
+    }
+
+    preProcessedFiles = PragmaProcessor.process(preProcessedFiles);
+
+    return preProcessedFiles;
+  }
+
   public static merge(files: FileList, main: string, options?: {
     skipFUGR?: boolean;
     newReportName?: string;
     appendAbapmergeMarker?: boolean;
   }): string {
-    this.files = files;
     if (!options) options = {};
 
-    if (options.skipFUGR) {
-      this.files = this.skipFUGR(this.files);
-    }
-    this.files = PragmaProcessor.process(this.files);
+    this.files = this.preProcessFiles(files, options);
+
     this.classes = new ClassList(this.files);
 
     let result = this.analyze(main, this.files.fileByName(main).getContents(), options.newReportName);

--- a/src/pragma.ts
+++ b/src/pragma.ts
@@ -52,7 +52,7 @@ export default class PragmaProcessor {
       }
 
       newFiles.push(hasPragma
-        ? new File(file.getFilename(), output.join("\n"))
+        ? new File(file.getFilepath(), output.join("\n"), true)
         : file);
     }
 

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -39,6 +39,7 @@ describe("CLI parse arguments", () => {
       noFooter: false,
       newReportName: undefined,
       outputFile: undefined,
+      runPreProcessorOnly: false,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -55,6 +56,7 @@ describe("CLI parse arguments", () => {
       noFooter: false,
       newReportName: undefined,
       outputFile: undefined,
+      runPreProcessorOnly: false,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -72,6 +74,7 @@ describe("CLI parse arguments", () => {
       noFooter: true,
       newReportName: undefined,
       outputFile: undefined,
+      runPreProcessorOnly: false,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -91,6 +94,7 @@ describe("CLI parse arguments", () => {
       noFooter: true,
       newReportName: "znewname",
       outputFile: undefined,
+      runPreProcessorOnly: false,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);
@@ -108,6 +112,7 @@ describe("CLI parse arguments", () => {
       noFooter: false,
       newReportName: undefined,
       outputFile: "some.file",
+      runPreProcessorOnly: false,
     };
     chai.assert.isNotNull(parsedArgs);
     chai.assert.deepEqual(parsedArgs, parsedArgsExpected);


### PR DESCRIPTION
The newly added CUA include into a local implementations has caused me some headaches. I wanted to do the single file merge but that does not work because we need to load the global class.

I used to be a C/C++ programmer and we used to stop compilation after preprocessing (gcc -E) - it replaces all macros and so on.

I consider all abapmerge pragmas as macros on steroids and thus stopping after processor makes sense to me.

I am not sure about how to save the results.

I had to pass a full file path in the ctor of "File" and I split it into dir and file in the constructor. However, that broke tests because you add "js/script.js" and then include it as "js/script.js" but when processing an abapGit repository, you ignore directory (so I had to enhance getOtherByName a little bit). Do you ever include files with directory in the name?

Your thoughts?