### PR TITLE
0.16.6: fix "Maximum call stack size exceeded"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abapmerge",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abapmerge",
-      "version": "0.16.5",
+      "version": "0.16.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abapmerge",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Merge ABAP INCLUDEs into single file",
   "bin": {
     "abapmerge": "./abapmerge"

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -40,7 +40,7 @@ export default class Merge {
 
   private static analyze(main: string, contents: string, newReportName?: string) {
     let output = "";
-    const lines = CollectStatements.collect(contents).split("\n");
+    let lines = CollectStatements.collect(contents).split("\n");
     let isMainReport = false;
 
     let lineNo = 0;
@@ -72,7 +72,7 @@ export default class Merge {
           const classLines = this.classes.getResult().split("\n");
           classLines.pop();
           // insert the class source code in the array at lineNo, this way they are analyzed later
-          lines.splice(lineNo, 0, ...classLines);
+          lines = [].concat(lines.slice(0, lineNo), classLines, lines.slice(lineNo, lines.length));
           break;
         }
 

--- a/test/skip_test_classes.ts
+++ b/test/skip_test_classes.ts
@@ -4,7 +4,7 @@ import Merge from "../src/merge";
 import FileList from "../src/file_list";
 
 describe("classes 1, test", () => {
-  it("something", () => {
+  it("something1", () => {
     const files = new FileList();
 
     files.push(new File("zmain.abap", "REPORT zmain.\n\nINCLUDE zinclude."));
@@ -22,7 +22,7 @@ describe("classes 1, test", () => {
 });
 
 describe("classes 2, remove test classes from friends", () => {
-  it("something", () => {
+  it("something2", () => {
     const files = new FileList();
 
     files.push(new File("zmain.abap", "REPORT zmain.\n\ndata: foo type ref to zcl_serialize."));


### PR DESCRIPTION
closes #434

rewrite spread operator use

this will use more memory, but its okay